### PR TITLE
Type data merging & overriding, string type emitting

### DIFF
--- a/gearman-packet.js
+++ b/gearman-packet.js
@@ -4,8 +4,9 @@ module.exports = require('./packet-types');
 module.exports.Emitter = require('./packet-emitter');
 module.exports.Parser = require('./packet-parser');
 
+var cachedDefaultTypeData;
 module.exports.withDefaultTypeData = function() {
-    return mergedTypeData( [ module.exports ] );
+    return cachedDefaultTypeData = cachedDefaultTypeData || mergedTypeData( [ module.exports ] );
 };
 
 module.exports.withTypeData = function( typeData ) {

--- a/gearman-packet.js
+++ b/gearman-packet.js
@@ -3,3 +3,41 @@
 module.exports = require('./packet-types');
 module.exports.Emitter = require('./packet-emitter');
 module.exports.Parser = require('./packet-parser');
+
+module.exports.withDefaultTypeData = function() {
+    return mergedTypeData( [ module.exports ] );
+};
+
+module.exports.withTypeData = function( typeData ) {
+    return mergedTypeData( [ module.exports, typeData ] );
+};
+
+module.exports.withOnlyTypeData = function( typeData ) {
+    return mergedTypeData( [ typeData ] );
+};
+
+function mergedTypeData( typeDataArray ) {
+    var packetTypes = {
+        types : {},
+        adminTypes : {},
+        typesById : []
+    };
+
+    typeDataArray.forEach( function( typeData ) {
+        if ( 'types' in typeData ) {
+            for ( var name in typeData.types ) {
+                packetTypes.types[name] = typeData.types[name];
+                packetTypes.types[name].name = name;
+                packetTypes.typesById[typeData.types[name].id] = typeData.types[name];
+            }
+        }
+        if ( 'adminTypes' in typeData ) {
+            for ( var adminName in typeData.adminTypes ) {
+                packetTypes.adminTypes[adminName] = typeData.adminTypes[adminName];
+                packetTypes.adminTypes[adminName].name = adminName;
+            }
+        }
+    } );
+
+    return packetTypes;
+}

--- a/packet-emitter.js
+++ b/packet-emitter.js
@@ -83,6 +83,14 @@ Emitter.prototype.encodeGearman = function (packet,done) {
     if (!packet.type) {
         throw new TypeError("Packet missing type in "+util.inspect(packet));
     }
+    if (typeof(packet.type) === 'string') {
+        if ( packet.type in this.packetTypeData.types ) {
+            packet.type = this.packetTypeData.types[ packet.type ];
+        }
+        else {
+            throw new TypeError("Invalid packet type name in "+util.inspect(packet));
+        }
+    }
     var args = this.encodeGearmanArgs(packet);
     var body = this.encodeGearmanBody(packet);
     var header = this.encodeGearmanHeader(packet,args.length+body.length);

--- a/packet-emitter.js
+++ b/packet-emitter.js
@@ -9,6 +9,15 @@ var Emitter = module.exports = function (options) {
     stream.Transform.call(this,options);
     this._writableState.objectMode = true;
     this._readableState.objectMode = false;
+    if ( options.withOnlyTypeData ) {
+        this.packetTypeData = Packet.withOnlyTypeData( options.withOnlyTypeData );
+    }
+    else if ( options.withTypeData ) {
+        this.packetTypeData = Packet.withTypeData( options.withTypeData );
+    }
+    else {
+        this.packetTypeData = Packet.withDefaultTypeData();
+    }
 }
 util.inherits(Emitter, stream.Transform);
 


### PR DESCRIPTION
I wanted to maintain the previous interface for default packets, so I ended up going a bit different route than your suggestion (adding types to emitter and parser is a constructor option).

I also noticed that the packet data dependency was not actually used in the emitter at all. The emitter expected that all relevant type data was already passed in with the packet type -attribute.

The dependency to packet types was however introduced back to the emitter with the third commit, which allows packet type to be defined by just using the packet's name (instead of providing the packet definition object).

I added some tests to verify the emitting works with string types, and along with those I also verified that the withTypeData and withOnlyTypeData work as expected.

Any suggestions and guidance is warmly welcome :)
